### PR TITLE
Use lodash.sortby to ensure stable sorting of rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "add-px-to-style": "^1.0.0",
     "lodash.debounce": "^4.0.6",
+    "lodash.sortby": "^4.6.0",
     "murmurhash-js": "^1.0.0"
   },
   "ava": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 
 import hash from 'murmurhash-js/murmurhash3_gc'
 import debounce from 'lodash.debounce'
+import sortBy from 'lodash.sortby'
 import createRules from './create-rules'
 
 export let styleTag = null
@@ -70,10 +71,12 @@ cxs.clearCache = () => {
 
 Object.defineProperty(cxs, 'rules', {
   get () {
-    return Object.keys(cache || {})
+    const unorderedRules = Object
+      .keys(cache || {})
       .map(k => cache[k] || false)
-      .filter(r => r.css.length)
-      .sort((a, b) => a.order - b.order)
+      .filter(r => r.css.length);
+
+    return sortBy(unorderedRules, 'order');
   }
 })
 
@@ -86,4 +89,3 @@ Object.defineProperty(cxs, 'css', {
 })
 
 export default cxs
-

--- a/src/index.js
+++ b/src/index.js
@@ -74,9 +74,9 @@ Object.defineProperty(cxs, 'rules', {
     const unorderedRules = Object
       .keys(cache || {})
       .map(k => cache[k] || false)
-      .filter(r => r.css.length);
+      .filter(r => r.css.length)
 
-    return sortBy(unorderedRules, 'order');
+    return sortBy(unorderedRules, 'order')
   }
 })
 


### PR DESCRIPTION
Found the source of the issues I was having! The problem was the usage of `Array#sort`. [Depending on the browser it's not necessarily a stable sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort), so it may not preserve the initial sequence of rules that have the same order number. In my case, it was putting smaller media queries after some larger media queries.
