### PR TITLE
Add flexbox properties to common declarations

### DIFF
--- a/src/common-declarations.js
+++ b/src/common-declarations.js
@@ -72,7 +72,7 @@ const commonDeclarations = {
   ],
 
   borderRadius: [ 0 ],
-  
+
   flex: [ 'none' ],
   flexDirection: [
     'column',

--- a/src/common-declarations.js
+++ b/src/common-declarations.js
@@ -73,6 +73,7 @@ const commonDeclarations = {
 
   borderRadius: [ 0 ],
   
+  flex: [ 'none' ],
   flexDirection: [
     'column',
     'row'

--- a/src/common-declarations.js
+++ b/src/common-declarations.js
@@ -10,6 +10,8 @@ const commonDeclarations = {
     'inline',
     'table',
     'table-cell',
+    'flex',
+    'inline-flex',
     'none'
   ],
 
@@ -69,7 +71,42 @@ const commonDeclarations = {
     'fixed'
   ],
 
-  borderRadius: [ 0 ]
+  borderRadius: [ 0 ],
+  
+  flexDirection: [
+    'column',
+    'row'
+  ],
+  flexWrap: [ 'wrap' ],
+  alignItems: [
+    'flex-start',
+    'flex-end',
+    'center',
+    'baseline',
+    'stretch'
+  ],
+  alignSelf: [
+    'flex-start',
+    'flex-end',
+    'center',
+    'baseline',
+    'stretch'
+  ],
+  justifyContent: [
+    'flex-start',
+    'flex-end',
+    'center',
+    'space-around',
+    'space-between'
+  ],
+  alignContent: [
+    'flex-start',
+    'flex-end',
+    'center',
+    'space-around',
+    'space-between',
+    'stretch'
+  ]
 }
 
 export default commonDeclarations


### PR DESCRIPTION
Adds `flex` and `inline-flex` to `display`, as well as the set values flexbox properties:
- `flex`
- `flexDirection`
- `flexWrap`
- `alignItems`
- `alignSelf`
- `justifyContent`
- `alignContent`
