### PR TITLE
Handle ms key prefix

### DIFF
--- a/src/create-rules.js
+++ b/src/create-rules.js
@@ -118,7 +118,7 @@ const createRuleset = (selector, styles, parent) => {
 const isObj = v => typeof v === 'object'
 const isArr = v => Array.isArray(v)
 const parseValue = (prop, val) => typeof val === 'number' ? addPx(prop, val) : val
-const kebab = (str) => str.replace(/([A-Z])/g, g => '-' + g.toLowerCase())
+const kebab = (str) => str.replace(/([A-Z]|^ms)/g, g => '-' + g.toLowerCase())
 
 export default createRules
 

--- a/test/cxs.js
+++ b/test/cxs.js
@@ -204,6 +204,18 @@ test('handles prefixed styles with array values', t => {
   t.regex(cxs.css, /\-ms\-flexbox/)
 })
 
+test('handles prefixed styles (including ms) in keys', t => {
+  t.pass(3)
+  t.notThrows(() => {
+    const prefixed = prefixer({
+      alignItems: 'center'
+    })
+    cxs(prefixed)
+  })
+  t.regex(cxs.css, /\-webkit\-align-items/)
+  t.regex(cxs.css, /\-ms\-flex-align/)
+})
+
 test('ignores null values', t => {
   cxs({
     color: 'tomato',


### PR DESCRIPTION
When using inline-style-prefixer ms keys are returned with a leading lowercase `ms`. The current kebab casing doesn't handle this.