### PR TITLE
replace ! with _ as classNames do not get escaped

### DIFF
--- a/src/atomic/index.js
+++ b/src/atomic/index.js
@@ -131,6 +131,7 @@ const P_REG = /%/g
 const SYMBOL_REG = /[&,:"\s]/g
 const AT_REG = /@/g
 const DOT_REG = /\./g
+const EXCL_REG = /!/g
 
 export const clean = (str) => ('' + str)
   .replace(BLANK_REG, '')
@@ -138,6 +139,7 @@ export const clean = (str) => ('' + str)
   .replace(SYMBOL_REG, '_')
   .replace(AT_REG, '_')
   .replace(DOT_REG, 'p')
+  .replace(EXCL_REG, '_')
 
 export const combine = (str = '') => (...args) => args
   .filter(a => a !== null)
@@ -214,4 +216,3 @@ cxs.getCss = getCss
 cxs.setOptions = setOptions
 
 export default cxs
-

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -195,6 +195,5 @@ test('className replaces !', t => {
   const className = cxs({
     color: 'red!important',
   });
-  console.log(className);
   t.is(className.includes('!'), false);
 })

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -191,3 +191,10 @@ test('can set prefix option', t => {
   t.regex(className, /^foo\-/)
 })
 
+test('className replaces !', t => {
+  const className = cxs({
+    color: 'red!important',
+  });
+  console.log(className);
+  t.is(className.includes('!'), false);
+})


### PR DESCRIPTION
If you use !important in a style the resulting className includes the Exclamation mark (!)
An exclamation mark is valid within a css class name, but needs escaping.
As I saw you replaced some other stuff before I went with replacing it with a _ instead of escaping it.
If wanted I could change the createStyle function to escape properly. But I think this is easier.

Please release once you've merged as this is blocking for the usage within my company.