### PR TITLE
Add a custom rules parser

### DIFF
--- a/src/atomic/index.js
+++ b/src/atomic/index.js
@@ -16,7 +16,8 @@ export const getCss = () => {
 }
 
 const options = {
-  prefix: ''
+  prefix: '',
+  customRuleParser: false
 }
 
 export const setOptions = (opts) => {
@@ -93,7 +94,9 @@ const createStyle = (key, value, media, children = '') => {
   const val = addPx(key, value)
   const className = createClassName(prop, value, prefix)
   const selector = '.' + className + children
-  const rule = `${selector}{${prop}:${val}}`
+  const rule = options.customRuleParser
+    ? options.customRuleParser({selector, prop, val, key})
+    : `${selector}{${prop}:${val}}`
   const css = media ? `${media}{${rule}}` : rule
 
   sheet.insert(css)

--- a/src/lite/index.js
+++ b/src/lite/index.js
@@ -17,7 +17,8 @@ export const getCss = () => {
 let count = 0
 
 const options = {
-  prefix: ''
+  prefix: '',
+  customRuleParser: false
 }
 
 export const setOptions = (opts) => {
@@ -82,7 +83,9 @@ const createStyle = (key, value, media, pseudo = '') => {
   const prop = hyphenate(key)
   const val = addPx(key, value)
 
-  const rule = selector + '{' + prop + ':' + val + '}'
+  const rule = options.customRuleParser
+    ? options.customRuleParser({selector, prop, val, key})
+    : `${selector}{${prop}:${val}}`
   const css = media ? media + '{' + rule + '}' : rule
 
   sheet.insert(css)

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -3,7 +3,7 @@ import test from 'ava'
 import { StyleSheet } from 'glamor/lib/sheet'
 import prefixer from 'inline-style-prefixer/static'
 import jsdom from 'jsdom-global'
-import cxs, { sheet, reset, getCss } from '../src/atomic'
+import cxs, { sheet, reset, getCss, hyphenate } from '../src/atomic'
 
 jsdom('<html></html>')
 
@@ -11,6 +11,22 @@ const style = {
   color: 'tomato',
   display: 'flex',
   fontSize: 32
+}
+
+const prefixRules = ({ selector, key, val }) => {
+  const declarations = prefixer({ [key]: val })
+  const createRule = (rules, key, value, i) =>
+    `${rules}${i > 0 ? ';' : ''}${hyphenate(key)}:${value}`
+  const declarationsStr = Object.keys(declarations).reduce((rules, key, i) => {
+    const value = declarations[key]
+    if (Array.isArray(value)) {
+      return value.reduce((acc, val, i) => (
+        createRule(acc, key, val, i)
+      ), '')
+    }
+    return createRule(rules, key, val, i)
+  }, '')
+  return `${selector}{${declarationsStr}}`
 }
 
 test.beforeEach(() => {
@@ -135,26 +151,26 @@ test('handles array values', t => {
 
 test('handles prefixed styles with array values', t => {
   t.pass(3)
+  cxs.setOptions({ customRuleParser: prefixRules })
   t.notThrows(() => {
-    const prefixed = prefixer({
+    cxs({
       display: 'flex'
     })
-    cxs(prefixed)
   })
-  t.regex(getCss(), /\-webkit\-flex/)
-  t.regex(getCss(), /\-ms\-flexbox/)
+  t.regex(getCss(), /display:-webkit-flex/)
+  t.regex(getCss(), /display:-ms-flexbox/)
 })
 
 test('handles prefixed styles (including ms) in keys', t => {
   t.pass(3)
+  cxs.setOptions({ customRuleParser: prefixRules })
   t.notThrows(() => {
-    const prefixed = prefixer({
+    cxs({
       alignItems: 'center'
     })
-    cxs(prefixed)
   })
-  t.regex(getCss(), /\-webkit\-align-items/)
-  t.regex(getCss(), /\-ms\-flex-align/)
+  t.regex(getCss(), /-webkit-align-items:/)
+  t.regex(getCss(), /-ms-flex-align:/)
 })
 
 test('ignores null values', t => {

--- a/test/lite.js
+++ b/test/lite.js
@@ -3,7 +3,7 @@ import test from 'ava'
 import { StyleSheet } from 'glamor/lib/sheet'
 import prefixer from 'inline-style-prefixer/static'
 import jsdom from 'jsdom-global'
-import cxs, { sheet, reset, getCss } from '../src/lite'
+import cxs, { sheet, reset, getCss, hyphenate } from '../src/lite'
 
 jsdom('<html></html>')
 
@@ -11,6 +11,22 @@ const style = {
   color: 'tomato',
   display: 'flex',
   fontSize: 32
+}
+
+const prefixRules = ({ selector, key, val }) => {
+  const declarations = prefixer({ [key]: val })
+  const createRule = (rules, key, value, i) =>
+    `${rules}${i > 0 ? ';' : ''}${hyphenate(key)}:${value}`
+  const declarationsStr = Object.keys(declarations).reduce((rules, key, i) => {
+    const value = declarations[key]
+    if (Array.isArray(value)) {
+      return value.reduce((acc, val, i) => (
+        createRule(acc, key, val, i)
+      ), '')
+    }
+    return createRule(rules, key, val, i)
+  }, '')
+  return `${selector}{${declarationsStr}}`
 }
 
 test.beforeEach(() => {
@@ -114,26 +130,26 @@ test('handles array values', t => {
 
 test('handles prefixed styles with array values', t => {
   t.pass(3)
+  cxs.setOptions({ customRuleParser: prefixRules })
   t.notThrows(() => {
-    const prefixed = prefixer({
+    cxs({
       display: 'flex'
     })
-    cxs(prefixed)
   })
-  t.regex(getCss(), /\-webkit\-flex/)
-  t.regex(getCss(), /\-ms\-flexbox/)
+  t.regex(getCss(), /display:-webkit-flex/)
+  t.regex(getCss(), /display:-ms-flexbox/)
 })
 
 test('handles prefixed styles (including ms) in keys', t => {
   t.pass(3)
+  cxs.setOptions({ customRuleParser: prefixRules })
   t.notThrows(() => {
-    const prefixed = prefixer({
+    cxs({
       alignItems: 'center'
     })
-    cxs(prefixed)
   })
-  t.regex(getCss(), /\-webkit\-align-items/)
-  t.regex(getCss(), /\-ms\-flex-align/)
+  t.regex(getCss(), /-webkit-align-items:/)
+  t.regex(getCss(), /-ms-flex-align:/)
 })
 
 test('ignores null values', t => {


### PR DESCRIPTION
For my specific use case, this allows atomic/lite style to add things like prefixing at a lower level. As adding these as a wrapper around CXS creates either multiple class names/rules for a single rule or (in the case of arrays) a broken style.

## Examples

### Prefixed Keys

```js
import cxs from 'cxs'
import prefixer from 'inline-style-prefixer/static'

const prefixed = prefixer({
  alignItems: 'center'
})
const cx = cxs(prefixed)
```

In this example `cx` will equal `webkit-box-align-center ms-flex-align-center align-items-center` instead of just `align-items-center`.

### Prefixed Values

```js
import cxs from 'cxs'
import prefixer from 'inline-style-prefixer/static'

const prefixed = prefixer({
  display: 'flex'
})
const cx = cxs(prefixed)
```

In this example the `cxs.getCss()` would include a broken rule:

```css
._19uyyw8 {
    display: -webkit-box,-moz-box,-ms-flexbox,-webkit-flex,flex;
}
```

## Proposed Solution

My proposed solution is to add to the existing options object and allow adding a custom rule parser at a lower level so prefixes can be added without affecting class names.

The adapted tests in this PR hopefully illustrate how it can be used.

### Example

```js
 const prefixRules = ({ selector, key, val }) => {
   const declarations = prefixer({ [key]: val })
   const createRule = (rules, key, value, i) =>
     `${rules}${i > 0 ? ';' : ''}${hyphenate(key)}:${value}`
   const declarationsStr = Object.keys(declarations).reduce((rules, key, i) => {
     const value = declarations[key]
     if (Array.isArray(value)) {
       return value.reduce((acc, val, i) => (
         createRule(acc, key, val, i)
       ), '')
     }
     return createRule(rules, key, val, i)
   }, '')
   return `${selector}{${declarationsStr}}`
 }

cxs.setOptions({ customRuleParser: prefixRules })
```