### PR TITLE
Add tests for & implement @supports support

### DIFF
--- a/src/atomic/index.js
+++ b/src/atomic/index.js
@@ -64,7 +64,7 @@ const parse = (obj, media, children = '') => {
       continue
     }
 
-    if (/^@media/.test(key)) {
+    if (/^@media/.test(key) || /^@supports/.test(key)) {
       parse(value, key, children)
         .forEach(className => {
           classNames.push(className)

--- a/src/monolithic/index.js
+++ b/src/monolithic/index.js
@@ -71,7 +71,7 @@ const parse = (selector, styles, media) => {
       parse(selector + key, value, media)
         .forEach(r => rules.push(r))
       continue
-    } else if (/^@media/.test(key)) {
+    } else if (/^@media/.test(key) || /^@supports/.test(key)) {
       parse(selector, value, key)
         .forEach(r => rules.push(r))
       continue

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -89,6 +89,18 @@ test('keeps @media rules order', t => {
   t.regex(rules[3], /64/)
 })
 
+test('creates @supports rules correctly', t => {
+  cxs({
+    '@supports (--bg: tomato)': {
+      background: 'tomato'
+    }
+  })
+  const rules = sheet.rules().map(rule => rule.cssText)
+  t.true(rules.some(rule => {
+    return /^@supports \(--bg: tomato\)\{\..+\{background/.test(rule)
+  }))
+})
+
 test('creates nested selectors', t => {
   t.plan(4)
   let cx

--- a/test/lite.js
+++ b/test/lite.js
@@ -89,6 +89,17 @@ test('keeps @media rules order', t => {
   t.regex(rules[3], /64/)
 })
 
+test('creates @supports rules correctly', t => {
+  cxs({
+    '@supports (--bg: tomato)': {
+      background: 'tomato'
+    }
+  })
+  const rules = sheet.rules().map(rule => rule.cssText)
+  t.true(rules.some(rule => {
+    return /^@supports \(--bg: tomato\)\{\..+\{background/.test(rule)
+  }))
+})
 
 test('dedupes repeated styles', t => {
   const dupe = {

--- a/test/monolithic.js
+++ b/test/monolithic.js
@@ -104,6 +104,18 @@ test('keeps @media rules order', t => {
   t.regex(rules[3], /64/)
 })
 
+test('creates @supports rules correctly', t => {
+  cxs({
+    '@supports (--bg: tomato)': {
+      background: 'tomato'
+    }
+  })
+  const rules = sheet.rules().map(rule => rule.cssText)
+  t.true(rules.some(rule => {
+    return /^@supports \(--bg: tomato\)\{\..+\{background/.test(rule)
+  }))
+})
+
 test('creates nested selectors', t => {
   t.plan(3)
   t.notThrows(() => {


### PR DESCRIPTION
This PR adds support for including `@supports` rules (https://developer.mozilla.org/en-US/docs/Web/CSS/@supports) in the same way you can currently add `@media` rules.  E.g.:

```
cxs({
  '@supports (--bg: tomato)': {
    background: 'tomato'
  }
})
```

Currently, cxs support for `@supports` varies across modes.  Lite mode works as expected without this PR, but monolithic and atomic modes generate inaccurate CSS.

This PR:

1. Adds tests to ensure correct `@supports` generation across modes.
2. Adds support for correct `@supports` rule generation in monolithic and atomic modes.