### PR TITLE
Prevent ordering issues with media queries

### DIFF
--- a/example/CssOutput.js
+++ b/example/CssOutput.js
@@ -20,7 +20,7 @@ const format = str => str
   .replace(/}/g, '\n}\n')
 
 const CssOutput = () => {
-  const rendered = min(cxs.css())
+  const rendered = min(cxs.getCss())
 
   return (
     <Box>
@@ -50,4 +50,3 @@ const cx = {
 }
 
 export default CssOutput
-

--- a/example/Header.js
+++ b/example/Header.js
@@ -62,7 +62,10 @@ const cx = {
     display: 'flex',
     alignItems: 'center',
     minHeight: '60vh',
-    backgroundColor: colors.primary
+    backgroundColor: colors.primary,
+    [breakpoints[2]]: {
+      fontSize: 40
+    }
   }),
   inner: cxs({
     maxWidth: '100%'
@@ -119,4 +122,3 @@ const cx = {
 }
 
 export default Header
-

--- a/src/atomic/index.js
+++ b/src/atomic/index.js
@@ -3,12 +3,14 @@ import { StyleSheet } from 'glamor/lib/sheet'
 import hash from '../hash'
 
 export const sheet = new StyleSheet()
+export const mediaSheet = new StyleSheet()
 
 sheet.inject()
+mediaSheet.inject()
 
 export const getCss = () => {
   let css = ''
-  const rules = sheet.rules()
+  const rules = sheet.rules().concat(mediaSheet.rules())
   for (let i = 0; i < rules.length; i++) {
     css += rules[i].cssText
   }
@@ -28,6 +30,7 @@ export const setOptions = (opts) => {
 export const reset = () => {
   cxs.cache = {}
   sheet.flush()
+  mediaSheet.flush()
 }
 
 const cxs = (style) => {
@@ -94,9 +97,12 @@ const createStyle = (key, value, media, children = '') => {
   const className = createClassName(prop, value, prefix)
   const selector = '.' + className + children
   const rule = `${selector}{${prop}:${val}}`
-  const css = media ? `${media}{${rule}}` : rule
 
-  sheet.insert(css)
+  if (media) {
+    mediaSheet.insert(`${media}{${rule}}`)
+  } else {
+    sheet.insert(rule)
+  }
   cxs.cache[id] = className
 
   return className

--- a/src/lite/index.js
+++ b/src/lite/index.js
@@ -2,12 +2,14 @@
 import { StyleSheet } from 'glamor/lib/sheet'
 
 export const sheet = new StyleSheet()
+export const mediaSheet = new StyleSheet()
 
 sheet.inject()
+mediaSheet.inject()
 
 export const getCss = () => {
   let css = ''
-  const rules = sheet.rules()
+  const rules = sheet.rules().concat(mediaSheet.rules())
   for (let i = 0; i < rules.length; i++) {
     css += rules[i].cssText
   }
@@ -30,6 +32,7 @@ export const setOptions = (opts) => {
 export const reset = () => {
   cxs.cache = {}
   sheet.flush()
+  mediaSheet.flush()
   count = 0
 }
 
@@ -83,9 +86,12 @@ const createStyle = (key, value, media, pseudo = '') => {
   const val = addPx(key, value)
 
   const rule = selector + '{' + prop + ':' + val + '}'
-  const css = media ? media + '{' + rule + '}' : rule
 
-  sheet.insert(css)
+  if (media) {
+    mediaSheet.insert(media + '{' + rule + '}')
+  } else {
+    sheet.insert(rule)
+  }
   cxs.cache[id] = className
 
   return className
@@ -176,4 +182,3 @@ cxs.rehydrate = rehydrate
 cxs.setOptions = setOptions
 
 export default cxs
-

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -3,7 +3,7 @@ import test from 'ava'
 import { StyleSheet } from 'glamor/lib/sheet'
 import prefixer from 'inline-style-prefixer/static'
 import jsdom from 'jsdom-global'
-import cxs, { sheet, reset, getCss } from '../src/atomic'
+import cxs, { sheet, mediaSheet, reset, getCss } from '../src/atomic'
 
 jsdom('<html></html>')
 
@@ -36,8 +36,9 @@ test('returns a consistent micro classname', t => {
   t.is(cx, cxtwo) // Double-double checking
 })
 
-test('has a glamor StyleSheet instance', t => {
+test('has glamor StyleSheet instances', t => {
   t.true(sheet instanceof StyleSheet)
+  t.true(mediaSheet instanceof StyleSheet)
 })
 
 test('Adds px unit to number values', t => {
@@ -82,11 +83,11 @@ test('keeps @media rules order', t => {
     }
   }
   cxs(sx)
-  const rules = sheet.rules().map(rule => rule.cssText)
-  t.is(rules.length, 4)
-  t.regex(rules[1], /32/)
-  t.regex(rules[2], /48/)
-  t.regex(rules[3], /64/)
+  const rules = mediaSheet.rules().map(rule => rule.cssText)
+  t.is(rules.length, 3)
+  t.regex(rules[0], /32/)
+  t.regex(rules[1], /48/)
+  t.regex(rules[2], /64/)
 })
 
 test('creates nested selectors', t => {

--- a/test/lite.js
+++ b/test/lite.js
@@ -3,7 +3,7 @@ import test from 'ava'
 import { StyleSheet } from 'glamor/lib/sheet'
 import prefixer from 'inline-style-prefixer/static'
 import jsdom from 'jsdom-global'
-import cxs, { sheet, reset, getCss } from '../src/lite'
+import cxs, { sheet, mediaSheet, reset, getCss } from '../src/lite'
 
 jsdom('<html></html>')
 
@@ -36,8 +36,9 @@ test('returns a sequential micro classname', t => {
   t.is(cx, cxtwo) // Double-double checking
 })
 
-test('has a glamor StyleSheet instance', t => {
+test('has glamor StyleSheet instances', t => {
   t.true(sheet instanceof StyleSheet)
+  t.true(mediaSheet instanceof StyleSheet)
 })
 
 test('Adds px unit to number values', t => {
@@ -82,11 +83,11 @@ test('keeps @media rules order', t => {
     }
   }
   cxs(sx)
-  const rules = sheet.rules().map(rule => rule.cssText)
-  t.is(rules.length, 4)
-  t.regex(rules[1], /32/)
-  t.regex(rules[2], /48/)
-  t.regex(rules[3], /64/)
+  const rules = mediaSheet.rules().map(rule => rule.cssText)
+  t.is(rules.length, 3)
+  t.regex(rules[0], /32/)
+  t.regex(rules[1], /48/)
+  t.regex(rules[2], /64/)
 })
 
 
@@ -208,4 +209,3 @@ test('can set prefix option', t => {
   const className = cxs({ color: 'tomato' })
   t.regex(className, /^foo\-/)
 })
-


### PR DESCRIPTION
Fixes #47.  See issue for discussions of other ways to solve the issue.

Due to how rules are rendered and cached in cxs, the ordering of rules for a specific element is nondeterministic.  This is not a problem in most cases due to css specificity, but media queries don't increase specificity so the ordering is important.  This PR enforces a specific ordering of media queries by always putting them into a second style block on the page.

This has a chance of being a breaking change if someone is relying on a media query to be included before the base rule.  But, I think most people write their css with media rules at the end and the previous resolution was nondeterministic.

I have tested this in the example and my own application which has a number of media rules and everything works well.  But, there might be a different usage pattern that I might have missed that would cause problems.

A few other notes:
* This is only needed for the two atomic modes, not `monolithic`.
* I added a media query to the example and fixed `css()` => `getCss()` that seemed like it changed at some point
* This always injects a second style object, even if no media rules are being used.  I considered having this happen only when a media rule is encountered.  I like the fact the current version guarantees that the two style blocks are injected together but could be convinced it is not worth the overhead for users not using media rules.


