### PR TITLE
Fix selectors duplication in “lite” version

### DIFF
--- a/src/lite/index.js
+++ b/src/lite/index.js
@@ -107,7 +107,7 @@ export const alphaHash = (n) => {
   return result
 }
 
-const alpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+const alpha = 'abcdefghijklmnopqrstuvwxyz'.split('')
 
 export const hyphenate = (str) => ('' + str)
   .replace(/[A-Z]|^ms/g, '-$&')


### PR DESCRIPTION
Css selectors are case-insensetive, so `alphaHash(0)` (`.a`) being matched with `alphaHash(26)` (`.A`)