### PR TITLE
feat(CSP): allow nonce

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     },
     {
       "path": "./dist/monolithic.js",
-      "maxSize": "1.0 kb"
+      "maxSize": "1.01 kb"
     }
   ]
 }

--- a/src/monolithic.js
+++ b/src/monolithic.js
@@ -49,16 +49,16 @@ const parse = obj => {
   const classNames = []
 
   rules.forEach(rule => {
-    const cacheKey = JSON.stringify(rule)
-    if (cache[cacheKey]) {
-      classNames.push(cache[cacheKey])
+    const key = JSON.stringify(rule)
+    if (cache[key]) {
+      classNames.push(cache[key])
       return
     }
     const className = prefix + cssRules.length.toString(36)
     classNames.push(className)
     const ruleset = createRule(Object.assign(rule, { className }))
     insert(ruleset)
-    cache[cacheKey] = className
+    cache[key] = className
   })
 
   return classNames.join(' ')
@@ -78,9 +78,9 @@ module.exports.reset = () => {
 module.exports.prefix = val => prefix = val
 
 if (typeof document !== 'undefined') {
-  const style = document.head.appendChild(
-    document.createElement('style')
-  )
+  const s = document.createElement('style')
+  if (window) s.nonce = window.__webpack_nonce__
+  const style = document.head.appendChild(s)
   const sheet = style.sheet
   style.id = '_cxs_'
   insert = rule => {


### PR DESCRIPTION
adding functionality for a nonce attribute to be applied to the injected style tag. This allows stricter CSP settings to be applied server side, while still allowing for style injection.

This follows a convention set by webpack as [seen here](https://github.com/webpack/webpack/pull/3210) (it's essentially undocumented functionality).

And follows a similar setup to how [styled components implements nonce attributes](https://github.com/styled-components/styled-components/pull/1022).

I tried to keep the bundle size under 1KB, but opted to bump up the threshold in favor of retaining readability of the file. If keeping it to 1KB is important, I can look for other savings? or maybe start uglifying this file to be a more representative format of what most consumers will ingest this lib as.